### PR TITLE
1.2.1: grant app pool SQL access on site creation; fix dev-mode compi…

### DIFF
--- a/AcuInstallerHelper/AcuInstallerHelper.psd1
+++ b/AcuInstallerHelper/AcuInstallerHelper.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'AcumaticaInstallerHelper.PowerShell.dll'
 
     # Version number of this module.
-    ModuleVersion     = '1.2.0'
+    ModuleVersion     = '1.2.1'
 
     # ID used to uniquely identify this module
     GUID                 = '1b6c3d2f-b6df-48c8-8c6b-d324e89badf7'
@@ -119,6 +119,15 @@
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
+            Version 1.2.1
+            - New-AcumaticaSite now grants the IIS app pool identity (IIS APPPOOL\<pool>) a SQL Server
+              login and db_owner membership on the site database. ac.exe only does this for pools the
+              interactive Configuration wizard creates; command-line deployments previously failed on
+              first request with "Login failed for user 'IIS APPPOOL\<pool>'".
+            - Development mode no longer sets pages compilationMode=Never, which broke every request
+              ("The attribute 'autoeventwireup' is not allowed in this page") because Acumatica's
+              master pages use CodeFile attributes that no-compile pages reject.
+
             Version 1.2.0
             - New-AcumaticaSite: added -Website and -AppPool parameters to target a specific IIS website and application pool
             - New-AcumaticaSite: pre-flight check fails fast with a clear error when the target IIS website does not exist

--- a/src/AcumaticaInstallerHelper.CLI/AcumaticaInstallerHelper.CLI.csproj
+++ b/src/AcumaticaInstallerHelper.CLI/AcumaticaInstallerHelper.CLI.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 <LangVersion>latest</LangVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <AssemblyName>AcumaticaInstallerHelper.PowerShell</AssemblyName>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/src/AcumaticaInstallerHelper.CLI/ServiceCollection.cs
+++ b/src/AcumaticaInstallerHelper.CLI/ServiceCollection.cs
@@ -39,7 +39,8 @@ namespace AcumaticaInstallerHelper.CLI
             var processManagerService = new ProcessManagerService(loggingService);
             var siteRegistryService = new SiteRegistryService(loggingService, webConfigService);
             var versionService = new VersionService(configService, loggingService, processManagerService, httpClient);
-            var siteService = new SiteService(versionService, argFactory, loggingService, siteRegistryService, webConfigService, processManagerService);
+            var sqlAccessService = new SqlAccessService(loggingService);
+            var siteService = new SiteService(versionService, argFactory, loggingService, siteRegistryService, webConfigService, processManagerService, sqlAccessService);
             var patchService = new PatchService(versionService, loggingService, processManagerService);
 
             return new AcumaticaManager(

--- a/src/AcumaticaInstallerHelper/AcumaticaInstallerHelper.csproj
+++ b/src/AcumaticaInstallerHelper/AcumaticaInstallerHelper.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 <LangVersion>latest</LangVersion>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>Lekker Solutions</Authors>
     <Company>Lekker Solutions</Company>
     <Product>Acumatica Installer Helper</Product>
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="System.Data.Odbc" Version="8.0.1" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>

--- a/src/AcumaticaInstallerHelper/Services/ISqlAccessService.cs
+++ b/src/AcumaticaInstallerHelper/Services/ISqlAccessService.cs
@@ -1,0 +1,13 @@
+using AcumaticaInstallerHelper.Models;
+
+namespace AcumaticaInstallerHelper.Services;
+
+public interface ISqlAccessService
+{
+    /// <summary>
+    ///     Grants the site's IIS application pool identity (IIS APPPOOL\&lt;pool&gt;)
+    ///     a Windows login on the SQL Server and db_owner membership on the
+    ///     site database, so the site can connect with integrated security.
+    /// </summary>
+    bool GrantAppPoolAccess(SiteConfiguration siteConfig);
+}

--- a/src/AcumaticaInstallerHelper/Services/SiteService.cs
+++ b/src/AcumaticaInstallerHelper/Services/SiteService.cs
@@ -12,6 +12,7 @@ public class SiteService : ISiteService
     private readonly ISiteRegistryService _siteRegistryService;
     private readonly IWebConfigService    _webConfigService;
     private readonly IProcessManagerService _processManagerService;
+    private readonly ISqlAccessService    _sqlAccessService;
 
     public SiteService(
         IVersionService      versionService,
@@ -19,7 +20,8 @@ public class SiteService : ISiteService
         ILoggingService      loggingService,
         ISiteRegistryService siteRegistryService,
         IWebConfigService webConfigService,
-        IProcessManagerService processManagerService)
+        IProcessManagerService processManagerService,
+        ISqlAccessService sqlAccessService)
     {
         _versionService      = versionService;
         _argFactory          = argFactory;
@@ -27,6 +29,7 @@ public class SiteService : ISiteService
         _siteRegistryService = siteRegistryService;
         _webConfigService    = webConfigService;
         _processManagerService = processManagerService;
+        _sqlAccessService    = sqlAccessService;
     }
 
     public bool RequiresAdministratorPrivileges()
@@ -139,6 +142,12 @@ public class SiteService : ISiteService
                 string webConfigPath = Path.Combine(siteConfig.SitePath, "web.config");
                 _webConfigService.ApplyDevelopmentConfiguration(webConfigPath);
             }
+
+            // ac.exe grants SQL access only to pools created by the interactive
+            // Configuration wizard; from the command line the pool identity is
+            // left without a login and the site fails on first request.
+            if (success)
+                success = _sqlAccessService.GrantAppPoolAccess(siteConfig);
 
             if (success)
                 _loggingService.WriteSummary("Site Installation", "Completed Successfully",

--- a/src/AcumaticaInstallerHelper/Services/SqlAccessService.cs
+++ b/src/AcumaticaInstallerHelper/Services/SqlAccessService.cs
@@ -1,0 +1,84 @@
+using System.Data.Odbc;
+using AcumaticaInstallerHelper.Models;
+
+namespace AcumaticaInstallerHelper.Services;
+
+/// <summary>
+///     Grants SQL Server access to the site's IIS application pool identity.
+///     ac.exe only does this for pools created interactively by the
+///     Configuration wizard — its command-line NewInstance scenario creates the
+///     pool and the database but no login, so a freshly deployed site fails
+///     with "Login failed for user 'IIS APPPOOL\&lt;pool&gt;'" on first request.
+///     Uses ODBC with the in-box Windows "SQL Server" driver so the module
+///     needs no SqlClient native dependencies.
+/// </summary>
+public class SqlAccessService : ISqlAccessService
+{
+    private readonly ILoggingService _loggingService;
+
+    public SqlAccessService(ILoggingService loggingService)
+    {
+        _loggingService = loggingService;
+    }
+
+    public bool GrantAppPoolAccess(SiteConfiguration siteConfig)
+    {
+        string login = $@"IIS APPPOOL\{siteConfig.IISAppPool}";
+
+        try
+        {
+            using var connection = new OdbcConnection(BuildConnectionString(siteConfig));
+            connection.Open();
+
+            _loggingService.WriteStep($"Granting SQL Server access to '{login}'");
+
+            string escapedLoginLiteral = login.Replace("'", "''");
+            string escapedLoginBracket = login.Replace("]", "]]");
+            string escapedDbBracket    = siteConfig.DBName.Replace("]", "]]");
+
+            ExecuteNonQuery(connection,
+                $"IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'{escapedLoginLiteral}') " +
+                $"CREATE LOGIN [{escapedLoginBracket}] FROM WINDOWS;");
+
+            ExecuteNonQuery(connection,
+                $"USE [{escapedDbBracket}]; " +
+                $"IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{escapedLoginLiteral}') " +
+                $"CREATE USER [{escapedLoginBracket}] FOR LOGIN [{escapedLoginBracket}]; " +
+                $"ALTER ROLE db_owner ADD MEMBER [{escapedLoginBracket}];");
+
+            _loggingService.WriteSuccess($"'{login}' has db_owner access to database '{siteConfig.DBName}'");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _loggingService.WriteError(
+                $"Failed to grant SQL Server access to '{login}' on database '{siteConfig.DBName}': {ex.Message}");
+            return false;
+        }
+    }
+
+    private static string BuildConnectionString(SiteConfiguration siteConfig)
+    {
+        // The legacy in-box "SQL Server" ODBC driver resolves 'localhost' over
+        // TCP/named pipes, which fails on instances that only listen on shared
+        // memory; '(local)' always uses shared memory for a local instance.
+        string server = siteConfig.DBServer;
+        if (string.IsNullOrEmpty(server)
+            || server.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+            || server == ".")
+        {
+            server = "(local)";
+        }
+
+        return siteConfig.DBServerAuth == DBServerAuthType.SQL
+            ? $"Driver={{SQL Server}};Server={server};Uid={siteConfig.DBServerUsername};Pwd={siteConfig.DBServerPassword};"
+            : $"Driver={{SQL Server}};Server={server};Trusted_Connection=yes;";
+    }
+
+    private static void ExecuteNonQuery(OdbcConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+}

--- a/src/AcumaticaInstallerHelper/Services/WebConfigService.cs
+++ b/src/AcumaticaInstallerHelper/Services/WebConfigService.cs
@@ -62,18 +62,12 @@ public class WebConfigService : IWebConfigService
                 compilationElement.SetAttributeValue("batch", "false");
                 
                 _loggingService.WriteDebug("Set optimizeCompilations=true and batch=false");
-
-                // Note: The pages element is not within compilation in the actual web.config structure
-                // It's a separate element under system.web
             }
 
-            // Find pages element under system.web (not within compilation)
-            var pagesElement = doc.Descendants("pages").FirstOrDefault();
-            if (pagesElement != null)
-            {
-                pagesElement.SetAttributeValue("compilationMode", "Never");
-                _loggingService.WriteDebug("Set pages compilationMode=Never");
-            }
+            // Deliberately no pages compilationMode change: Acumatica's master
+            // pages use CodeFile attributes, which no-compile pages reject —
+            // setting compilationMode=Never breaks every request with
+            // "The attribute 'autoeventwireup' is not allowed in this page".
 
             doc.Save(webConfigPath);
             _loggingService.WriteSuccess("Development configuration applied to web.config");


### PR DESCRIPTION
…lationMode

- New-AcumaticaSite now grants IIS APPPOOL\<pool> a SQL Server login and db_owner on the site database (new SqlAccessService, ODBC via the in-box Windows "SQL Server" driver - pwsh ships System.Data.Odbc in $PSHOME, so no new packaged dependencies). ac.exe grants no SQL access from the command line (-dbwinauth/-dbnewuser change nothing; only the interactive Configuration wizard grants), so CLI-deployed sites failed on first request with "Login failed for user 'IIS APPPOOL\<pool>'". Local server aliases (localhost, .) are normalized to (local): the legacy ODBC driver resolves localhost over TCP/named pipes and fails when the instance only listens on shared memory.
- ApplyDevelopmentConfiguration no longer sets pages compilationMode=Never: Acumatica master pages use CodeFile attributes, which no-compile pages reject - every request failed with "The attribute 'autoeventwireup' is not allowed in this page".

Verified live on win2025-epyc: fresh 25.101.0153 instance deployed via New-AcumaticaSite -Website/-AppPool reaches the login page (200) with the grant created by the module.